### PR TITLE
Replace bitbucket.org to github.com

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,7 +111,7 @@ Other Resources
 
 Source code here:
 
-https://bitbucket.org/mjs7231/django-dbbackup/
+https://github.com/mjs7231/django-dbbackup
 
 PyPi project:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ that are at least present when using PyPi repositories.
 
 ::
 
-    pip install -e hg+https://bitbucket.org/mjs7231/django-dbbackup
+    pip install -e git+https://github.com/mjs7231/django-dbbackup.git#egg=django-dbbackup
 
 
 Adding in your project

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     author_email='mjs7231@gmail.com',
     install_requires=get_requirements(),
     license='BSD',
-    url='http://bitbucket.org/mjs7231/django-dbbackup',
+    url='https://github.com/mjs7231/django-dbbackup',
     keywords=['django', 'dropbox', 'database', 'backup', 'amazon', 's3'],
     packages=packages
 )


### PR DESCRIPTION
Replace bitbucket.org to github.com in docs and setup.py