### PR TITLE
'Fixed' the list backup functionality for the restore.

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -157,4 +157,5 @@ class Command(LabelCommand):
         print("Listing backups on %s in /%s:" % (self.storage.name, self.storage.backup_dir))
         for filepath in self.storage.list_directory():
             print("  %s" % os.path.basename(filepath))
-            print(utils.filename_details(filepath))
+            # TODO: Implement filename_details method
+            # print(utils.filename_details(filepath))

--- a/dbbackup/storage/ftp_storage.py
+++ b/dbbackup/storage/ftp_storage.py
@@ -44,6 +44,7 @@ class Storage(BaseStorage):
     #  DBBackup Storage Methods
     ###################################
 
+    @property
     def backup_dir(self):
         return self.FTP_PATH
 

--- a/dbbackup/storage/s3_storage.py
+++ b/dbbackup/storage/s3_storage.py
@@ -40,6 +40,7 @@ class Storage(BaseStorage):
         if not self.S3_SECRET_KEY:
             raise StorageError('Filesystem storage requires DBBACKUP_S3_SECRET_KEY to be defined in settings.')
 
+    @property
     def backup_dir(self):
         return self.S3_DIRECTORY
 

--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -113,3 +113,8 @@ def create_spooled_temporary_file(filepath):
     finally:
         tmpfile.close()
     return spooled_file
+
+
+def filename_details(filepath):
+    # TODO: What was this function made for ?
+    return ''


### PR DESCRIPTION
The list backup functionnality was throwing an attribute error due to a missing method in utils.

The backup dir display was also wrong because of the missing property decorator on some storage.

Before (ignore the new line after each filename):
--

<img width="617" alt="screen shot 2015-07-06 at 23 44 14" src="https://cloud.githubusercontent.com/assets/6633740/8534969/8b89f36c-2439-11e5-859b-dac2c48a12ea.png">

After:
--
<img width="399" alt="screen shot 2015-07-06 at 23 46 39" src="https://cloud.githubusercontent.com/assets/6633740/8534983/ac04ac9a-2439-11e5-86b5-fbd959cd5edb.png">

